### PR TITLE
Possibility of renaming project?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_authors():
 
 
 setup(
-    name='gping',
+    name='gevent-ping',
     version="0.1",
     description='A gevent fork of python-ping.',
     author=get_authors(),


### PR DESCRIPTION
Hey,
A month or so ago [I made a tool called gping](https://github.com/orf/gping) that got quite popular, however your project was using the `gping` package name on PyPi already so I called it `pinggraph` instead. 

I wanted to reach out to you to ask if perhaps I could use the `gping`package name instead? The only reason I ask is that it seems like this project hasn't been updated in a long time, but if you want to keep it then that's completely fine and I understand.

Thanks!
